### PR TITLE
Do not die on missing file

### DIFF
--- a/lib/Dist/Zilla/Plugin/Prereqs/EnsureVersion.pm
+++ b/lib/Dist/Zilla/Plugin/Prereqs/EnsureVersion.pm
@@ -20,7 +20,7 @@ sub setup_installer {
 
     state $pmversions = do {
         my $path = File::HomeDir->my_home . "/pmversions.ini";
-        my $hoh = Config::IOD::Reader->new->read_file($path);
+        my $hoh = (-e $path) ? Config::IOD::Reader->new->read_file($path) : {};
         $hoh->{GLOBAL} // {};
     };
 


### PR DESCRIPTION
This plugin reads a set of minimum versions from `~/pmversions.ini`, but unfamiliar developers (like myself) will not have that file on their machines, and will also likely not know what versions to require even if they did have the file.

This patch makes it easier for new developers to make contributions, by mapping a missing `~/pmversions.ini` to an empty set of minimum requirements.
